### PR TITLE
[ADYENPLAT-32] fixed various inconsistencies with adyen account creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added the ability to show the latest Active account if the user has Closed accounts
+
+### Fixed
+
+- Fixed various inconsistencies due to removal of dispatch
+- Fixed a bug where the account status would not update after an account is closed
+
 ## [0.1.2] - 2022-03-01
 
 ### Fixed

--- a/node/services/adyenService.ts
+++ b/node/services/adyenService.ts
@@ -75,7 +75,14 @@ export default {
 
     if (!accounts) return null
 
-    const [{ accountHolderCode }] = accounts
+    let [{ accountHolderCode }] = accounts
+
+    for (const account of accounts) {
+      if (account.status !== 'Closed') {
+        accountHolderCode = account.accountHolderCode
+        break
+      }
+    }
 
     return ctx.clients.adyenClient.getAccountHolder(
       accountHolderCode,

--- a/react/SellerDetail.tsx
+++ b/react/SellerDetail.tsx
@@ -24,6 +24,12 @@ const SellerDetail: FC = () => {
     onboarding: null,
     seller: null,
     adyenAccountHolder: null,
+    setContextState: (inputState: any) => {
+      setState((prevState: any) => ({
+        ...prevState,
+        ...inputState,
+      }))
+    },
   })
 
   const { loading: loadingS, data: sellerData } = useQuery(Seller, {

--- a/react/components/sellerCloseAccountModal.tsx
+++ b/react/components/sellerCloseAccountModal.tsx
@@ -17,13 +17,14 @@ import {
 import { useMutation } from 'react-apollo'
 
 import CLOSE_ACCOUNT_HOLDER from '../graphql/CloseAccountHolder.graphql'
+import { StateContext } from '../context/StateContext'
 
 const SellerCloseAccountModal: FC<any> = ({ adyenAccountHolder }) => {
   const [isLoading, setIsLoading] = useState(false)
   const [deleteAccountHolder] = useMutation(CLOSE_ACCOUNT_HOLDER)
   const publishModal = useModalState()
 
-  const handleClose = async () => {
+  const handleClose = async (setContextState: any) => {
     setIsLoading(true)
     try {
       await deleteAccountHolder({
@@ -42,53 +43,62 @@ const SellerCloseAccountModal: FC<any> = ({ adyenAccountHolder }) => {
       message: 'Adyen account deleted',
     })
 
+    adyenAccountHolder.accountHolderStatus.status = 'Closed'
+    setContextState({ adyenAccountHolder })
+
     publishModal.hide()
   }
 
   return (
-    <Set spacing={3}>
-      <ModalDisclosure state={publishModal}>
-        <Button
-          disabled={adyenAccountHolder.accountHolderStatus?.status === 'Closed'}
-          variant="danger"
-        >
-          Close Account
-        </Button>
-      </ModalDisclosure>
-      <StatelessModal
-        aria-label="Close Adyen account modal"
-        state={publishModal}
-        size="regular"
-        hideOnClickOutside={false}
-      >
-        <StatelessModal.Header title="Close Adyen Account" />
-        <StatelessModal.Content>
-          <Text>Close the Adyen account associated with this seller.</Text>
-          <Alert
-            csx={{ marginTop: 6 }}
-            type="warning"
-            icon={<IconWarningColorful />}
-            visible
+    <StateContext.Consumer>
+      {({ setContextState }) => (
+        <Set spacing={3}>
+          <ModalDisclosure state={publishModal}>
+            <Button
+              disabled={
+                adyenAccountHolder.accountHolderStatus?.status === 'Closed'
+              }
+              variant="danger"
+            >
+              Close Account
+            </Button>
+          </ModalDisclosure>
+          <StatelessModal
+            aria-label="Close Adyen account modal"
+            state={publishModal}
+            size="regular"
+            hideOnClickOutside={false}
           >
-            This action cannot be undone. This account will no longer be able to
-            process payments or receive payouts.
-          </Alert>
-        </StatelessModal.Content>
-        <StatelessModal.Footer>
-          <ModalButton closeModalOnClick variant="secondary">
-            Cancel
-          </ModalButton>
-          <ModalButton
-            loading={isLoading}
-            disabled={isLoading}
-            variant="danger"
-            onClick={async () => handleClose()}
-          >
-            Close
-          </ModalButton>
-        </StatelessModal.Footer>
-      </StatelessModal>
-    </Set>
+            <StatelessModal.Header title="Close Adyen Account" />
+            <StatelessModal.Content>
+              <Text>Close the Adyen account associated with this seller.</Text>
+              <Alert
+                csx={{ marginTop: 6 }}
+                type="warning"
+                icon={<IconWarningColorful />}
+                visible
+              >
+                This action cannot be undone. This account will no longer be
+                able to process payments or receive payouts.
+              </Alert>
+            </StatelessModal.Content>
+            <StatelessModal.Footer>
+              <ModalButton closeModalOnClick variant="secondary">
+                Cancel
+              </ModalButton>
+              <ModalButton
+                loading={isLoading}
+                disabled={isLoading}
+                variant="danger"
+                onClick={async () => handleClose(setContextState)}
+              >
+                Close
+              </ModalButton>
+            </StatelessModal.Footer>
+          </StatelessModal>
+        </Set>
+      )}
+    </StateContext.Consumer>
   )
 }
 

--- a/react/components/sellerOnboarding.tsx
+++ b/react/components/sellerOnboarding.tsx
@@ -22,8 +22,7 @@ import REFRESH_ONBOARDING from '../graphql/RefreshOnboarding.graphql'
 import { StateContext } from '../context/StateContext'
 
 const SellerOnboarding: FC<any> = () => {
-  const { seller, adyenAccountHolder, onboarding, dispatch } =
-    useContext(StateContext)
+  const { seller, adyenAccountHolder, onboarding } = useContext(StateContext)
 
   const [onboardUrl, setOnboardUrl] = useState('')
   const [isLoading, setIsLoading] = useState(false)
@@ -47,7 +46,7 @@ const SellerOnboarding: FC<any> = () => {
     workspace,
   ])
 
-  const handleRefresh = async () => {
+  const handleRefresh = async (setContextState: any) => {
     setIsLoading(true)
 
     try {
@@ -57,10 +56,7 @@ const SellerOnboarding: FC<any> = () => {
         },
       })
 
-      dispatch({
-        type: 'SET_ONBOARDING',
-        onboarding: response.data.refreshOnboarding,
-      })
+      setContextState({ onboarding: response.data.refreshOnboarding })
     } catch (error) {
       console.error(error)
       setIsLoading(false)
@@ -100,22 +96,23 @@ const SellerOnboarding: FC<any> = () => {
               holder.
             </Paragraph>
             <Set>
-              <SellerOnboardingModal
-                seller={seller}
-                dispatch={dispatch}
-                disabled={isActive}
-              />
+              <SellerOnboardingModal seller={seller} disabled={isActive} />
               {isActive && (
-                <Button
-                  variant="primary"
-                  loading={isLoading}
-                  disabled={
-                    adyenAccountHolder.accountHolderStatus?.status !== 'Active'
-                  }
-                  onClick={() => handleRefresh()}
-                >
-                  Create New Link
-                </Button>
+                <StateContext.Consumer>
+                  {({ setContextState }) => (
+                    <Button
+                      variant="primary"
+                      loading={isLoading}
+                      disabled={
+                        adyenAccountHolder.accountHolderStatus?.status !==
+                        'Active'
+                      }
+                      onClick={() => handleRefresh(setContextState)}
+                    >
+                      Create New Link
+                    </Button>
+                  )}
+                </StateContext.Consumer>
               )}
             </Set>
             {onboardUrl && (

--- a/react/components/sellerOnboardingModal.tsx
+++ b/react/components/sellerOnboardingModal.tsx
@@ -19,10 +19,11 @@ import {
   IconErrorColorful,
 } from '@vtex/admin-ui'
 import { useMutation } from 'react-apollo'
+import { StateContext } from '../context/StateContext'
 
 import CREATE_ACCOUNT_HOLDER from '../graphql/CreateAccountHolder.graphql'
 
-const SellerOnboardingModal: FC<any> = ({ seller, dispatch, disabled }) => {
+const SellerOnboardingModal: FC<any> = ({ seller, disabled }) => {
   const [legalBusinessName, setLegalBusinessName] = useState('')
   const [email, setEmail] = useState('')
   const [accountHolderCode, setAccountHolderCode] = useState(seller?.id)
@@ -46,7 +47,7 @@ const SellerOnboardingModal: FC<any> = ({ seller, dispatch, disabled }) => {
     initialSelectedItem: legalEntities[0],
   })
 
-  const createAccount = async () => {
+  const createAccount = async (setContextState: any) => {
     setErrors([])
     setIsLoading(true)
     let response = null
@@ -79,11 +80,7 @@ const SellerOnboardingModal: FC<any> = ({ seller, dispatch, disabled }) => {
       return setErrors(invalidFields)
     }
 
-    dispatch({
-      type: 'CREATE_ADYEN_ACCOUNT',
-      onboarding,
-      adyenAccountHolder,
-    })
+    setContextState({ onboarding, adyenAccountHolder })
 
     toast.dispatch({
       type: 'success',
@@ -94,93 +91,97 @@ const SellerOnboardingModal: FC<any> = ({ seller, dispatch, disabled }) => {
   }
 
   return (
-    <Set spacing={3}>
-      <ModalDisclosure state={publishModal}>
-        <Button disabled={disabled} variant="primary">
-          Create Adyen Account
-        </Button>
-      </ModalDisclosure>
-      <StatelessModal
-        aria-label="Create Adyen account modal"
-        state={publishModal}
-        size="regular"
-        hideOnClickOutside={false}
-      >
-        <StatelessModal.Header title="Create Adyen Account" />
-        <StatelessModal.Content>
-          <Text>
-            Enter the required information to create an Adyen account for the
-            seller.
-          </Text>
-          <Box csx={{ marginTop: '15px', marginBottom: '15px' }}>
-            <Input
-              id="accountHolderCode"
-              label="Adyen Account Holder Code"
-              helperText="A unique identifier used in the Adyen dashboard"
-              value={accountHolderCode}
-              onChange={e => setAccountHolderCode(e.target.value)}
-            />
-          </Box>
-          <Set orientation="vertical" spacing={1}>
-            <Select
-              block
-              items={countries}
-              state={countryState}
-              label="Country"
-              renderItem={(item: any) => item.label}
-            />
-            <Select
-              block
-              items={legalEntities}
-              state={legalEntityState}
-              label="Legal Entity Type"
-              renderItem={(item: any) => item.label}
-            />
-          </Set>
-          <Input
-            id="legalBusinessName"
-            label="Legal Business Name"
-            value={legalBusinessName}
-            onChange={e => setLegalBusinessName(e.target.value)}
-          />
-          <Input
-            id="email"
-            type="email"
-            label="Business Email"
-            value={email}
-            onChange={e => setEmail(e.target.value)}
-          />
-          {errors.length > 0 && (
-            <Alert
-              csx={{ marginTop: '15px' }}
-              type="error"
-              icon={<IconErrorColorful />}
-              visible={errors.length > 0}
-            >
-              {errors.map((error, i) => (
-                <div key={i}>{error.errorDescription}</div>
-              ))}
-            </Alert>
-          )}
-        </StatelessModal.Content>
-        <StatelessModal.Footer>
-          <ModalButton
-            onClick={() => setErrors([])}
-            closeModalOnClick
-            variant="secondary"
+    <StateContext.Consumer>
+      {({ setContextState }) => (
+        <Set spacing={3}>
+          <ModalDisclosure state={publishModal}>
+            <Button disabled={disabled} variant="primary">
+              Create Adyen Account
+            </Button>
+          </ModalDisclosure>
+          <StatelessModal
+            aria-label="Create Adyen account modal"
+            state={publishModal}
+            size="regular"
+            hideOnClickOutside={false}
           >
-            Cancel
-          </ModalButton>
-          <ModalButton
-            loading={isLoading}
-            disabled={isLoading}
-            onClick={async () => createAccount()}
-          >
-            Create
-          </ModalButton>
-        </StatelessModal.Footer>
-      </StatelessModal>
-    </Set>
+            <StatelessModal.Header title="Create Adyen Account" />
+            <StatelessModal.Content>
+              <Text>
+                Enter the required information to create an Adyen account for
+                the seller.
+              </Text>
+              <Box csx={{ marginTop: '15px', marginBottom: '15px' }}>
+                <Input
+                  id="accountHolderCode"
+                  label="Adyen Account Holder Code"
+                  helperText="A unique identifier used in the Adyen dashboard"
+                  value={accountHolderCode}
+                  onChange={e => setAccountHolderCode(e.target.value)}
+                />
+              </Box>
+              <Set orientation="vertical" spacing={1}>
+                <Select
+                  block
+                  items={countries}
+                  state={countryState}
+                  label="Country"
+                  renderItem={(item: any) => item.label}
+                />
+                <Select
+                  block
+                  items={legalEntities}
+                  state={legalEntityState}
+                  label="Legal Entity Type"
+                  renderItem={(item: any) => item.label}
+                />
+              </Set>
+              <Input
+                id="legalBusinessName"
+                label="Legal Business Name"
+                value={legalBusinessName}
+                onChange={e => setLegalBusinessName(e.target.value)}
+              />
+              <Input
+                id="email"
+                type="email"
+                label="Business Email"
+                value={email}
+                onChange={e => setEmail(e.target.value)}
+              />
+              {errors.length > 0 && (
+                <Alert
+                  csx={{ marginTop: '15px' }}
+                  type="error"
+                  icon={<IconErrorColorful />}
+                  visible={errors.length > 0}
+                >
+                  {errors.map((error, i) => (
+                    <div key={i}>{error.errorDescription}</div>
+                  ))}
+                </Alert>
+              )}
+            </StatelessModal.Content>
+            <StatelessModal.Footer>
+              <ModalButton
+                onClick={() => setErrors([])}
+                closeModalOnClick
+                variant="secondary"
+              >
+                Cancel
+              </ModalButton>
+              <ModalButton
+                loading={isLoading}
+                disabled={isLoading}
+                onClick={async () => createAccount(setContextState)}
+              >
+                Create
+              </ModalButton>
+            </StatelessModal.Footer>
+          </StatelessModal>
+        </Set>
+      )}
+    </StateContext.Consumer>
   )
 }
 

--- a/react/context/StateContext.tsx
+++ b/react/context/StateContext.tsx
@@ -4,7 +4,7 @@ const initialState = {
   onboarding: null,
   seller: null,
   adyenAccountHolder: null,
-  dispatch: null,
+  setContextState: () => {},
 }
 
 export const StateContext = React.createContext(initialState as any)


### PR DESCRIPTION
**What problem is this solving?**
- Fixed various inconsistencies due to removal of dispatch
- Fixed a bug where the account status would not update after an account is closed
- Added the ability to show the latest Active account if the user has Closed accounts

**How should this be manually tested?**
Workspace: https://weiworkspace--sandboxusdev.myvtex.com/admin/adyen-for-platforms/sandboxusdev01/
Account Details will now show the latest Active account instead of showing the first account made. If a new account is created, it will show that one. If there are no Active accounts, it will revert to the previous rule.

![image](https://user-images.githubusercontent.com/32426660/155419276-6718cc70-aba1-45ce-9b89-409290646199.png)

Closing Accounts will change the account status to Close
![image](https://user-images.githubusercontent.com/32426660/155419316-24e9a42e-a0e6-4b97-91dd-3e601e0e66f1.png)

Note: This also solves the ticket ADYENPLAT-29