### PR TITLE
[ADYENPLAT-35] added processing tier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added a processing tier selection on the account creation modal
+
 ## [0.2.1] - 2022-03-03
 
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -133,6 +133,7 @@ type Mutation {
     legalBusinessName: String!
     email: String!
     legalEntity: String!
+    processingTier: Int!
   ): AdyenAccountStatus
   closeAccountHolder(accountHolderCode: String!): Onboarding
   onboardingComplete(accountHolderCode: String!): Onboarding

--- a/node/api/resolvers/adyen.ts
+++ b/node/api/resolvers/adyen.ts
@@ -7,6 +7,7 @@ export interface CreateAccountHolderDTO {
   legalBusinessName: string
   email: string
   legalEntity: string
+  processingTier: number
 }
 
 export interface AccountUpdateDTO {

--- a/node/services/adyenService.ts
+++ b/node/services/adyenService.ts
@@ -13,12 +13,19 @@ export default {
     ctx: Context
     data: CreateAccountHolderDTO
   }) => {
-    const { country, legalBusinessName, legalEntity, email, sellerId } = data
+    const {
+      country,
+      legalBusinessName,
+      legalEntity,
+      email,
+      sellerId,
+      processingTier,
+    } = data
 
     const accountHolder = {
       accountHolderCode: data.accountHolderCode,
       legalEntity,
-      processingTier: 3,
+      processingTier,
       accountHolderDetails: {
         address: {
           country,

--- a/react/components/sellerOnboardingModal.tsx
+++ b/react/components/sellerOnboardingModal.tsx
@@ -34,6 +34,12 @@ const SellerOnboardingModal: FC<any> = ({ seller, disabled }) => {
 
   const countries = [{ id: 'US', label: 'United States' }]
   const legalEntities = [{ id: 'Business', label: 'Business' }]
+  const processingTiers = [
+    { id: 0, label: 'Tier 0' },
+    { id: 1, label: 'Tier 1' },
+    { id: 2, label: 'Tier 2' },
+    { id: 3, label: 'Tier 3' },
+  ]
 
   const countryState = useSelectState({
     items: countries,
@@ -45,6 +51,12 @@ const SellerOnboardingModal: FC<any> = ({ seller, disabled }) => {
     items: legalEntities,
     itemToString: (item: any) => item.label,
     initialSelectedItem: legalEntities[0],
+  })
+
+  const processingTierState = useSelectState({
+    items: processingTiers,
+    itemToString: (item: any) => item.label,
+    initialSelectedItem: processingTiers[0],
   })
 
   const createAccount = async (setContextState: any) => {
@@ -61,6 +73,7 @@ const SellerOnboardingModal: FC<any> = ({ seller, disabled }) => {
           legalBusinessName,
           email,
           legalEntity: legalEntityState.selectedItem?.id,
+          processingTier: processingTierState.selectedItem?.id,
         },
       })
     } catch (error) {
@@ -133,6 +146,13 @@ const SellerOnboardingModal: FC<any> = ({ seller, disabled }) => {
                   items={legalEntities}
                   state={legalEntityState}
                   label="Legal Entity Type"
+                  renderItem={(item: any) => item.label}
+                />
+                <Select
+                  block
+                  items={processingTiers}
+                  state={processingTierState}
+                  label="Processing Tier"
                   renderItem={(item: any) => item.label}
                 />
               </Set>

--- a/react/graphql/CreateAccountHolder.graphql
+++ b/react/graphql/CreateAccountHolder.graphql
@@ -5,6 +5,7 @@ mutation createAccountHolder(
   $legalBusinessName: String!
   $email: String!
   $legalEntity: String!
+  $processingTier: Int!
 ) {
   createAccountHolder(
     accountHolderCode: $accountHolderCode
@@ -13,6 +14,7 @@ mutation createAccountHolder(
     legalBusinessName: $legalBusinessName
     email: $email
     legalEntity: $legalEntity
+    processingTier: $processingTier
   ) @context(provider: "vtex.adyen-platforms") {
     adyenAccountHolder {
       accountHolderCode


### PR DESCRIPTION
**What problem is this solving?**

We needed to add a processing tier selection. Certain clients can only have maximum tier of N (Between 0 and 3, inclusive). Originally, it was hard coded as tier 3, which prevented some from creating an account.

**How should this be manually tested?**

Linked Here: https://weiworkspace--sandboxusdev.myvtex.com/admin/adyen-for-platforms
Create Adyen Account should have a new dropdown for picking the processing tiers.

**Screenshots or example usage:**

![image](https://user-images.githubusercontent.com/32426660/162492348-5b7e5d85-13fc-4f6a-878b-09429be4b89a.png)
