### PR TITLE
[ADYENPLAT-37] Fix account info mismatch between Adyen Menu and Seller Details page; Fix bug displaying wrong payouts schedule on initial navigation to Seller Details page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a bug where the Adyen Menu page got seller's account status from first account listed instead of first active account
+- Fixed a bug where Payouts dropdown in Seller Detail page displayed `Daily` instead of saved payout schedule
+
 ## [0.3.2] - 2022-06-08
 
 ### Added

--- a/node/clients/masterdata/account.ts
+++ b/node/clients/masterdata/account.ts
@@ -101,14 +101,12 @@ export class Account extends MasterData {
         schema: ACCOUNT_SCHEMA_VERSION,
       })
 
-      // return first active account if available
-      for (const account of accounts) {
-        if (account.status === 'Active') {
-          return account
-        }
-      }
+      if (!accounts.length) return null
 
-      return accounts[0] || null
+      // return first active account if available
+      return (
+        accounts.find(account => account.status === 'Active') ?? accounts[0]
+      )
     } catch (error) {
       return null
     }

--- a/node/clients/masterdata/account.ts
+++ b/node/clients/masterdata/account.ts
@@ -102,7 +102,7 @@ export class Account extends MasterData {
       })
 
       // return first active account if available
-      for(const account of accounts){
+      for (const account of accounts) {
         if (account.status === 'Active') {
           return account
         }

--- a/node/clients/masterdata/account.ts
+++ b/node/clients/masterdata/account.ts
@@ -101,6 +101,13 @@ export class Account extends MasterData {
         schema: ACCOUNT_SCHEMA_VERSION,
       })
 
+      // return first active account if available
+      for(const account of accounts){
+        if (account.status === 'Active') {
+          return account
+        }
+      }
+
       return accounts[0] || null
     } catch (error) {
       return null
@@ -132,6 +139,7 @@ export class Account extends MasterData {
           dataEntity: DATA_ENTITY,
           fields: ['sellerId', 'accountHolderCode', 'accountCode', 'status'],
           pagination: { page: 1, pageSize: 100 },
+          schema: ACCOUNT_SCHEMA_VERSION,
         })
 
       return accounts.data

--- a/react/components/sellerPayouts.tsx
+++ b/react/components/sellerPayouts.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react'
-import React, { useContext, useState } from 'react'
+import React, { useContext, useState, useEffect } from 'react'
 import { useMutation } from 'react-apollo'
 import {
   Box,
@@ -55,14 +55,22 @@ const SellerPayouts: FC<any> = () => {
 
   const [updateAccount] = useMutation(UPDATE_ACCOUNT)
   const [account] = adyenAccountHolder?.accounts || []
+
   const state = useSelectState({
     items: SCHEDULE_OPTIONS,
     itemToString: (item: any) => item.label,
-    initialSelectedItem:
-      SCHEDULE_OPTIONS.find(
-        i => i.value === account?.payoutSchedule.schedule
-      ) ?? SCHEDULE_OPTIONS[0],
+    initialSelectedItem: SCHEDULE_OPTIONS[0],
   })
+
+  useEffect(() => {
+    if (account?.payoutSchedule.schedule) {
+      const selectedItem: any = SCHEDULE_OPTIONS.find(
+        i => i.value === account?.payoutSchedule.schedule
+      ) ?? SCHEDULE_OPTIONS[0]
+  
+      state.selectItem(selectedItem)
+    }
+  }, [account?.payoutSchedule.schedule])
 
   return (
     <Columns spacing={1}>

--- a/react/components/sellerPayouts.tsx
+++ b/react/components/sellerPayouts.tsx
@@ -64,10 +64,11 @@ const SellerPayouts: FC<any> = () => {
 
   useEffect(() => {
     if (account?.payoutSchedule.schedule) {
-      const selectedItem: any = SCHEDULE_OPTIONS.find(
-        i => i.value === account?.payoutSchedule.schedule
-      ) ?? SCHEDULE_OPTIONS[0]
-  
+      const selectedItem: any =
+        SCHEDULE_OPTIONS.find(
+          i => i.value === account?.payoutSchedule.schedule
+        ) ?? SCHEDULE_OPTIONS[0]
+
       state.selectItem(selectedItem)
     }
   }, [account?.payoutSchedule.schedule])

--- a/react/components/sellerPayouts.tsx
+++ b/react/components/sellerPayouts.tsx
@@ -63,75 +63,86 @@ const SellerPayouts: FC<any> = () => {
   })
 
   useEffect(() => {
-    if (account?.payoutSchedule.schedule) {
-      const selectedItem: any =
-        SCHEDULE_OPTIONS.find(
-          i => i.value === account?.payoutSchedule.schedule
-        ) ?? SCHEDULE_OPTIONS[0]
-
-      state.selectItem(selectedItem)
+    if (!account?.payoutSchedule.schedule) {
+      return
     }
+
+    const selectedItem: any =
+      SCHEDULE_OPTIONS.find(
+        i => i.value === account?.payoutSchedule.schedule
+      ) ?? SCHEDULE_OPTIONS[0]
+
+    state.selectItem(selectedItem)
   }, [account?.payoutSchedule.schedule])
 
+  const handleUpdate = async (setContextState: any) => {
+    setIsLoading(true)
+
+    try {
+      const response = await updateAccount({
+        variables: {
+          accountCode: account.accountCode,
+          schedule: state.selectedItem?.value,
+        },
+      })
+
+      account.payoutSchedule.schedule = response.data.updateAccount.schedule
+      setContextState({ adyenAccountHolder })
+    } catch (err) {
+      setIsLoading(false)
+
+      toast.dispatch({
+        type: 'error',
+        message: 'Unable to update payout schedule',
+      })
+
+      return
+    }
+
+    setIsLoading(false)
+    toast.dispatch({
+      type: 'success',
+      message: 'Payout schedule updated',
+    })
+  }
+
   return (
-    <Columns spacing={1}>
-      <Columns.Item>
-        <Box>
-          <Set orientation="vertical" spacing={3} fluid>
-            <Heading>Payouts</Heading>
-            <Paragraph csx={{ width: '60%' }}>
-              Set seller payout schedule.
-            </Paragraph>
-            <Set spacing={3}>
-              <Select
-                items={SCHEDULE_OPTIONS}
-                state={state}
-                label="Schedule"
-                renderItem={(item: any) => item.label}
-              />
-              <Paragraph csx={{ width: '60%' }}>
-                {state.selectedItem?.description}
-              </Paragraph>
-            </Set>
-          </Set>
-        </Box>
-        <Button
-          loading={isLoading}
-          disabled={!adyenAccountHolder}
-          variant="primary"
-          csx={{ marginTop: '20px' }}
-          onClick={async (_e: any) => {
-            setIsLoading(true)
-
-            try {
-              await updateAccount({
-                variables: {
-                  accountCode: account.accountCode,
-                  schedule: state.selectedItem?.value,
-                },
-              })
-            } catch (err) {
-              setIsLoading(false)
-
-              toast.dispatch({
-                type: 'error',
-                message: 'Unable to update payout schedule',
-              })
-
-              return
-            }
-
-            setIsLoading(false)
-            toast.dispatch({
-              type: 'success',
-              message: 'Payout schedule updated',
-            })
-          }}
-        >
-          Save
-        </Button>
-      </Columns.Item>
-    </Columns>
+    <StateContext.Consumer>
+      {({ setContextState }) => (
+        <Columns spacing={1}>
+          <Columns.Item>
+            <Box>
+              <Set orientation="vertical" spacing={3} fluid>
+                <Heading>Payouts</Heading>
+                <Paragraph csx={{ width: '60%' }}>
+                  Set seller payout schedule.
+                </Paragraph>
+                <Set spacing={3}>
+                  <Select
+                    items={SCHEDULE_OPTIONS}
+                    state={state}
+                    label="Schedule"
+                    renderItem={(item: any) => item.label}
+                  />
+                  <Paragraph csx={{ width: '60%' }}>
+                    {state.selectedItem?.description}
+                  </Paragraph>
+                </Set>
+              </Set>
+            </Box>
+            <Button
+              loading={isLoading}
+              disabled={!adyenAccountHolder}
+              variant="primary"
+              csx={{ marginTop: '20px' }}
+              onClick={() => handleUpdate(setContextState)}
+            >
+              Save
+            </Button>
+          </Columns.Item>
+        </Columns>
+      )}
+    </StateContext.Consumer>
   )
 }
 


### PR DESCRIPTION
**What problem is this solving?**

- Fixed a bug where the Adyen Menu page got seller's account status from first account listed in Master Data instead of first _active_ account
- Fixed a bug where Payouts dropdown in Seller Detail page displayed `Daily` instead of saved payout schedule

**How should this be manually tested?**

Test in workspace [anna](https://anna--gmheritageprod.myvtex.com/admin/adyen-for-platforms/).

_Bug: Seller Status_
The status in Adyen Menu table should match status in seller's Account Details section. Status of seller vtxowi3674 should be "Active". Compare status in _master_ workspace with status displayed in _anna_ workspace.

_Bug: Payouts Schedule_
1. Select seller [vtxowi3674](https://anna--gmheritageprod.myvtex.com/admin/adyen-for-platforms/vtxowi3674/)
2. Update payout schedule to "Monthly", "Weekly", or "Twice Weekly" (whatever's not already set) and save
3. Navigate back to [Adyen Menu](https://anna--gmheritageprod.myvtex.com/admin/adyen-for-platforms/) and then back to vtxowi3674 details page
4. Notice that payout schedule is updated 
 
Previously, only "Daily" was displayed even though the `adyenAccountHolder` query had the correct schedule saved.

<img width="1440" alt="Screen Shot 2022-07-11 at 6 07 54 PM" src="https://user-images.githubusercontent.com/53097865/178367152-252d648e-5f5e-4d86-abad-79b644c026bc.png">
