### PR TITLE
[ADYENPLAT-39] Fix payout schedule displayed when default schedule set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed label displayed for payout schedule when `DEFAULT` returned by Adyen
+
+### Changed
+
+- Removed `Yearly` payout schedule. Not an option in Adyen
+
 ## [0.4.0] - 2022-08-01
 
 ### Added

--- a/node/services/adyenService.ts
+++ b/node/services/adyenService.ts
@@ -161,12 +161,12 @@ export default {
         payoutSchedule: { schedule },
       } = response
 
-      const updatedPayoutSchedules = await vbase.getJSON<{
+      const savedPayoutSchedules = await vbase.getJSON<{
         [accountCode: string]: string
       }>('adyen-platforms', 'updatedPayoutSchedule', true)
 
       await vbase.saveJSON('adyen-platforms', 'updatedPayoutSchedule', {
-        ...updatedPayoutSchedules,
+        ...savedPayoutSchedules,
         [accountCode]: schedule,
       })
 

--- a/node/services/sellerService.ts
+++ b/node/services/sellerService.ts
@@ -1,4 +1,4 @@
-import { settings } from './utils'
+import { replaceDefaultSchedule, settings } from './utils'
 
 function getAccount({
   seller,
@@ -103,6 +103,12 @@ export default {
       const adyenAccountHolder = await adyenClient.getAccountHolder(
         account.accountHolderCode,
         await settings(ctx)
+      )
+
+      adyenAccountHolder.accounts = await replaceDefaultSchedule(
+        ctx,
+        adyenAccountHolder.accounts,
+        account.accountCode
       )
 
       const [onboarding] =

--- a/node/services/utils.ts
+++ b/node/services/utils.ts
@@ -27,13 +27,13 @@ export const replaceDefaultSchedule = async (
     clients: { vbase },
   } = context
 
-  const recentlySavedSchedules = await vbase.getJSON<{
+  const savedPayoutSchedules = await vbase.getJSON<{
     [accountCode: string]: string
   }>('adyen-platforms', 'updatedPayoutSchedule', true)
 
   if (
-    !recentlySavedSchedules ||
-    !Object.prototype.hasOwnProperty.call(recentlySavedSchedules, accountCode)
+    !savedPayoutSchedules ||
+    !Object.prototype.hasOwnProperty.call(savedPayoutSchedules, accountCode)
   ) {
     return accounts
   }
@@ -46,7 +46,7 @@ export const replaceDefaultSchedule = async (
       return {
         ...account,
         payoutSchedule: {
-          schedule: recentlySavedSchedules[accountCode],
+          schedule: savedPayoutSchedules[accountCode],
         },
       }
     }

--- a/node/services/utils.ts
+++ b/node/services/utils.ts
@@ -17,3 +17,40 @@ export const settings = async (context: Context): Promise<any> => {
     return null
   }
 }
+
+export const replaceDefaultSchedule = async (
+  context: Context,
+  accounts: Account[],
+  accountCode: string
+): Promise<Account[]> => {
+  const {
+    clients: { vbase },
+  } = context
+
+  const recentlySavedSchedules = await vbase.getJSON<{
+    [accountCode: string]: string
+  }>('adyen-platforms', 'updatedPayoutSchedule', true)
+
+  if (
+    !recentlySavedSchedules ||
+    !Object.prototype.hasOwnProperty.call(recentlySavedSchedules, accountCode)
+  ) {
+    return accounts
+  }
+
+  return accounts.map(account => {
+    if (
+      accountCode === account.accountCode &&
+      account.payoutSchedule?.schedule === 'DEFAULT'
+    ) {
+      return {
+        ...account,
+        payoutSchedule: {
+          schedule: recentlySavedSchedules[accountCode],
+        },
+      }
+    }
+
+    return account
+  })
+}

--- a/node/typings/adyen.d.ts
+++ b/node/typings/adyen.d.ts
@@ -14,6 +14,14 @@ interface GetAccountHolderResponse {
       checks: Check[]
     }
   }
+  accounts: Account[]
+}
+
+interface Account {
+  accountCode: string
+  payoutSchedule: {
+    schedule: string
+  }
 }
 
 interface GetOnboardingUrlRequest {

--- a/react/SellerDetail.tsx
+++ b/react/SellerDetail.tsx
@@ -47,7 +47,7 @@ const SellerDetail: FC = () => {
     onCompleted: () => {
       setState((prevState: any) => ({
         ...prevState,
-        adyenAccountHolder: adyenData.adyenAccountHolder,
+        adyenAccountHolder: adyenData?.adyenAccountHolder,
       }))
     },
   })

--- a/react/components/sellerPayouts.tsx
+++ b/react/components/sellerPayouts.tsx
@@ -42,11 +42,6 @@ const SCHEDULE_OPTIONS = [
     value: 'BIWEEKLY_ON_1ST_AND_15TH_AT_MIDNIGHT',
     description: 'Monthly on the 1st and 15th at midnight (00:00:00 CET).',
   },
-  {
-    label: 'Yearly',
-    value: 'YEARLY',
-    description: 'Every year on January 1st at midnight (00:00:00 CET).',
-  },
 ]
 
 const SellerPayouts: FC<any> = () => {


### PR DESCRIPTION
**What problem is this solving?**
For context, each platform in Adyen for Platforms can have multiple accounts associated with it. The platform has a default payout schedule but each account can set a payout schedule different from that. However, for accounts using the default payout schedule, `DEFAULT` is returned when getting the account info and this value cannot be mapped to the schedule options in `SellerPayouts` (see options listed [here](https://docs.adyen.com/marketplaces-and-platforms/classic/payouts/scheduled-payout#change-payout-schedule)). Since the value cannot be mapped, the "Daily" option is displayed, giving the impression that the payout schedule update failed.

In this PR, the app will check for the most recently saved schedule value for the seller if `DEFAULT` is returned and replace `DEFAULT` with the value saved. Basically, it maps `DEFAULT` to a valid schedule option for the connected Adyen platform.

**How should this be manually tested?**
Test in workspace [annaadyenplat](https://annaadyenplat--sandboxusdev.myvtex.com/admin/adyen-for-platforms/). The default schedule for this test account is `DAILY_US` so I added an extra option to the schedule options mapping for this workspace. Saving a seller's payout schedule to "Daily US" should display "Daily US" instead of "Daily" even after reloading the page.

**Screenshots or example usage:**
<img width="638" alt="Screen Shot 2022-08-12 at 1 56 02 PM" src="https://user-images.githubusercontent.com/53097865/184416072-f95e944a-7417-44d2-926e-27e63810d9e5.png">