### PR TITLE
Fix: check schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,24 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- During any masterdata operation, check if schema exists and create it if not
+
 ### Added
+
 - Updated cy-runner.yml file in adyen platforms
 
 ### Added
+
 - cy-runner is added for cypress e2e automation
 
 ### Added
+
 - GitHub Dispatch workflow added
 
 ### Changed
+
 - GitHub reusable workflow uptaded to v2
 
 ## [0.4.1] - 2022-08-22

--- a/node/clients/masterdata/account.ts
+++ b/node/clients/masterdata/account.ts
@@ -85,6 +85,8 @@ export class Account extends MasterData {
   }
 
   public async find(data: { [key: string]: string }) {
+    await this.checkSchema()
+
     const [key] = Object.keys(data)
 
     return this.searchDocuments<IAdyenAccount>({
@@ -97,6 +99,7 @@ export class Account extends MasterData {
   }
 
   public async findBySellerId(data: string[]) {
+    await this.checkSchema()
     const where = `sellerId=${data.join(' OR sellerId=')}`
 
     return this.searchDocuments<IAdyenAccount>({
@@ -109,6 +112,8 @@ export class Account extends MasterData {
   }
 
   public async all() {
+    await this.checkSchema()
+
     return this.searchDocumentsWithPaginationInfo<IAdyenAccount>({
       dataEntity: DATA_ENTITY,
       fields: ['sellerId', 'accountHolderCode', 'accountCode', 'status'],

--- a/node/package.json
+++ b/node/package.json
@@ -10,7 +10,7 @@
     "@types/co-body": "^0.0.3",
     "@types/node": "^12.0.0",
     "@types/uuid": "^8.3.0",
-    "@vtex/api": "6.45.12",
+    "@vtex/api": "6.45.15",
     "tslint": "^5.12.0",
     "tslint-config-vtex": "^2.1.0",
     "typescript": "3.9.7",

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -174,10 +174,10 @@
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
   integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
 
-"@vtex/api@6.45.12":
-  version "6.45.12"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.12.tgz#b13c04398b12f576263ea823369f09c970d57479"
-  integrity sha512-SVLKo+Q/TxQy+1UKzH8GswTI3F2OCRCLfgaNQOrVAVdbM6Ci4wzTeX8j/S4Q1aEEnqBFlH/wVpHf8I6NBa+g9A==
+"@vtex/api@6.45.15":
+  version "6.45.15"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-6.45.15.tgz#aa987d22f7df16ce2861130deda6ffd63156817b"
+  integrity sha512-Rg1VGDzJ4hHUNp1vSidMdGGPojr1PikMTptlZsJ3oNZVdEo4cPx2l8ZcAEwHWORL7QjPjXaEgmeA5ZOSf+boCQ==
   dependencies:
     "@types/koa" "^2.11.0"
     "@types/koa-compose" "^3.2.3"


### PR DESCRIPTION
**What problem is this solving?**

Previously, the app would only create/update the MasterData schema when saving documents. When testing this app for the Hearst project, an error was being thrown when attempting to create a new seller Adyen account because the app was attempting to query MasterData before the schema had been created. Now, the schema will be checked before any MasterData operation, and created if necessary.

**How should this be manually tested?**

Linked here: https://arthur--demohearst.myvtex.com/admin